### PR TITLE
add software-properties common

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:14.04
 MAINTAINER Brandon Amos <brandon.amos.cs@gmail.com>
 RUN apt-get update
 RUN apt-get install curl git -y
+RUN apt-get install -y software-properties-common
 
 RUN curl -s https://raw.githubusercontent.com/torch/ezinstall/master/install-deps | bash -e
 RUN git clone https://github.com/torch/distro.git ~/torch --recursive


### PR DESCRIPTION
fixes the following error when running curl -s https://raw.githubusercontent.com/torch/ezinstall/master/install-deps | bash -e
which causes the build to fail and seems to be due to a dependency on add-apt-repository for install-deps.

sudo: add-apt-repository: command not found
The command '/bin/sh -c curl -s https://raw.githubusercontent.com/torch/ezinstall/master/install-deps | bash -e' returned a non-zero code: 1